### PR TITLE
add configuration feature for s2s vpn using IPSEC and calico

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
+## 0.4.0
+### added features
+#### Calico static routes
+Support to set static routes on all hosts, which do not run CGW, for use in conjunction with calico.
+
+This feature will be used to connect two sides using CGW with IPSEC, where at least one is a Kubernetes cluster
+using Calico as a networking layer.
+
+Please consider the [README](README.md) for usage.
+
 ## 0.3.0
 ### incompatible changes
 #### PSK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+## 0.3.0
+### incompatible changes
+#### PSK
+
+The PSK for IPSEC has now to be set in the field `value:` of the psk key.
+
+Now:
+
+```yaml
+ipsec:
+  psk:
+    value: <the secret psk>
+```
+
+Before:
+
+```yaml
+ipsec:
+  psk: <the secret psk>
+```
+
+This is due to the feature of using kubernetes secrets instead of values in the helm config itself.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: cgw
-version: 0.3.0
+version: 0.3.1

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: cgw
-version: 0.3.1
+version: 0.4.0

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: cgw
-version: 0.2.1
+version: 0.3.0

--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@ connectivity gateway
 
 ## Configuration
 
+### VTI
+
+To disable the usage of VTI and therefor use policy based routing set the key to false:
+
+```yaml
+ipsec:
+  vti_key: false
+```
+
 ### IPSEC
 #### PSK
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,42 @@
 connectivity gateway
 
 ## Configuration
+
+### IPSEC
+#### PSK
+
+To the pre-shared key for the connection, you can either set it directly in you values:
+
+```yaml
+ipsec:
+  psk: "<my-very-secret-psk>"
+```
+
+This is though discouraged, because the secrets might be commited to you repository.
+
+Instead, also a kubernetes secret can be used as following:
+
+```yaml
+ipsec:
+  psk:
+    secret:
+      name: <name of the secret>
+      key: <name of the key in the secret>
+```
+
+### Calico
+
+In a setup, where the calico network should be connected to another side transparently with this CGW.
+If the following options are set, a route will automatically be set on the host and calico will be
+reconfigured to accept and propagate this route.
+
+ATTENTION: Because of changes on you infrastructure, use this option with care!
+
+```yaml
+calcioSetup:
+  enabled: true
+```
+
 ### VXLAN
 
 VXLAN endpoints inside the CGW can be created by adding a configuration under the `vxlan` key.

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -45,6 +45,7 @@ spec:
         securityContext:
           capabilities:
             add: ["NET_ADMIN"]
+      {{- if .Values.ipsec.vti_key }}
       - name: init-vti
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         command: ["/usr/local/bin/start-strongswan.sh", "init"]
@@ -65,6 +66,7 @@ spec:
           name: host-kernel-modules-volume
         securityContext:
           privileged: true
+      {{- end }}
 
       {{ if .Values.gre.enabled }}
       ##  GRE Tunneling ##
@@ -155,8 +157,10 @@ spec:
           value: "{{ .Values.ipsec.forceudp }}"
         - name: IPSEC_IKEREAUTH
           value: "{{ .Values.ipsec.ikereauth }}"
+        {{- if .Values.ipsec.vti_key }}
         - name: IPSEC_VTI_KEY
           value: "{{ .Values.ipsec.vti_key }}"
+        {{- end }}
         securityContext:
           privileged: true
         volumeMounts:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -137,7 +137,14 @@ spec:
         - name: IPSEC_REMOTENET
           value: "{{ .Values.ipsec.remotenet }}"
         - name: IPSEC_PSK
-          value: "{{ .Values.ipsec.psk }}"
+        {{- if .Values.ipsec.psk.secret }}
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.ipsec.psk.secret.name }}"
+              key: "{{ .Values.ipsec.psk.secret.key }}"
+        {{- else }}
+          value: "{{ .Values.ipsec.psk.value }}"
+        {{- end }}
         - name: IPSEC_KEYEXCHANGE
           value: "{{ .Values.ipsec.keyexchange }}"
         - name: IPSEC_IKECIPHER

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
         app: {{ template "CGW.name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.ipsec.hostNetworking }}
+      hostNetwork: true
+      {{- end }}
       initContainers:
       - name: init-ip
         image: thzpub/vnf-swak-diag
@@ -110,6 +113,7 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if not .Values.ipsec.hostNetworking }}
         ports:
         - containerPort: 500
           name: u500
@@ -117,11 +121,17 @@ spec:
         - containerPort: 4500
           name: u4500
           protocol: UDP
+        {{- end }}
         env:
         - name: USE_ENV_CONFIG
           value: "{{ .Values.useEnvConfig }}"
+        {{- if .Values.ipsec.setDefaultTable }}
         - name: SET_ROUTE_DEFAULT_TABLE
-          value: "{{ .Values.setRouteDefaultTable }}"
+          value: "TRUE"
+        {{- else }}
+        - name: SET_ROUTE_DEFAULT_TABLE
+          value: "FALSE"
+        {{- end }}
         - name: IPSEC_LOCALPRIVIP
           value: "{{ .Values.ipsec.localprivip }}"
 #        - name: IPSEC_LOCALPUBIP
@@ -162,7 +172,8 @@ spec:
           value: "{{ .Values.ipsec.vti_key }}"
         {{- end }}
         securityContext:
-          privileged: true
+          capabilities:
+            add: ["NET_ADMIN"]
         volumeMounts:
         - mountPath: /lib/modules
           name: host-kernel-modules-volume

--- a/templates/routes-for-calico.yaml
+++ b/templates/routes-for-calico.yaml
@@ -1,9 +1,38 @@
 # This file deploys the components necessary to patch calico and add routes to the host
 {{- if .Values.calicoSetup.enabled }}
-apiVersion: extension/v1beta1
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "CGW.fullname" .}}-calico-setup
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "CGW.fullname" .}}-calico-setup
+rules:
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get", "watch", "list"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "CGW.fullname" .}}-calico-setup
+subjects:
+- kind: ServiceAccount
+  name: {{ template "CGW.fullname" .}}-calico-setup
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: {{ template "CGW.fullname" .}}-calico-setup
+
+---
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "CGW.fullname" . }}-calicoSetup
+  name: {{ template "CGW.fullname" . }}-calico-setup
   namespace: kube-system
   label: 
     app: {{ template "CGW.name" . }}
@@ -18,6 +47,7 @@ spec:
         app: {{ template "CGW.name" . }}
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ template "CGW.fullname" .}}-calico-setup
       initContainers:
       - name: {{ .Chart.Name }}-calico-etcd-routing-enabler
         image: "quay.io/coreos/etcd:latest"
@@ -37,7 +67,7 @@ spec:
         - name: REMOTENET
           value: "{{ .Values.ipsec.remotenet }}"
       containers:
-      - name: {{ .Chart.Name }}-calicoSetup
+      - name: {{ .Chart.Name }}-calico-setup
         image: "{{ .Values.calicoSetup.image.repository }}:{{ .Values.calicoSetup.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
@@ -45,11 +75,15 @@ spec:
           value: {{ template "CGW.fullname" . }}
         - name: IPSEC_REMOTENET
           value: "{{ .Values.ipsec.remotenet }}"
+        - name: IPSEC_NAMESPACE
+          value: "{{ .Release.Namespace }}"
         securityContext:
-          privileged: true
-        hostNetwork: true
+          capabilities:
+            add: ["NET_ADMIN"]
+      hostNetwork: true
    {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
    {{- end }}
+
 {{- end }}

--- a/templates/routes-for-calico.yaml
+++ b/templates/routes-for-calico.yaml
@@ -1,0 +1,55 @@
+# This file deploys the components necessary to patch calico and add routes to the host
+{{- if .Values.calicoSetup.enabled }}
+apiVersion: extension/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "CGW.fullname" . }}-calicoSetup
+  namespace: kube-system
+  label: 
+    app: {{ template "CGW.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "CGW.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      initContainers:
+      - name: {{ .Chart.Name }}-calico-etcd-routing-enabler
+        image: "quay.io/coreos/etcd:latest"
+        command:
+          - /bin/sh
+          - "-xc"
+          - >
+              etcdctl --endpoint=$ENDPOINT set
+              calico/bgp/v1/global/custom_filters/v4/ipsec
+              "if ( net = $REMOTENET ) then { accept ; }"
+        env:
+        - name: ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: calico-config
+              key: etcd_endpoints
+        - name: REMOTENET
+          value: "{{ .Values.ipsec.remotenet }}"
+      containers:
+      - name: {{ .Chart.Name }}-calicoSetup
+        image: "{{ .Values.calicoSetup.image.repository }}:{{ .Values.calicoSetup.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: IPSEC_SERVICE
+          value: {{ template "CGW.fullname" . }}
+        - name: IPSEC_REMOTENET
+          value: "{{ .Values.ipsec.remotenet }}"
+        securityContext:
+          privileged: true
+        hostNetwork: true
+   {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+   {{- end }}
+{{- end }}

--- a/templates/routes-for-calico.yaml
+++ b/templates/routes-for-calico.yaml
@@ -65,8 +65,8 @@ spec:
           trap _term TERM INT
           while true
           do
-            echo "going to sleep for 1d"
-            sleep 1d
+            echo "going to infinite sleep"
+            sleep 3
           done
 
         env:

--- a/templates/routes-for-calico.yaml
+++ b/templates/routes-for-calico.yaml
@@ -1,89 +1,82 @@
 # This file deploys the components necessary to patch calico and add routes to the host
 {{- if .Values.calicoSetup.enabled }}
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ template "CGW.fullname" .}}-calico-setup
-  namespace: kube-system
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ template "CGW.fullname" .}}-calico-setup
-rules:
-- apiGroups: [""]
-  resources: ["endpoints"]
-  verbs: ["get", "watch", "list"]
-
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ template "CGW.fullname" .}}-calico-setup
-subjects:
-- kind: ServiceAccount
-  name: {{ template "CGW.fullname" .}}-calico-setup
-  namespace: kube-system
-roleRef:
-  kind: ClusterRole
-  name: {{ template "CGW.fullname" .}}-calico-setup
-
----
-apiVersion: extensions/v1beta1
-kind: Deployment
+apiVersion: apps/v1beta2
+kind: DaemonSet
 metadata:
   name: {{ template "CGW.fullname" . }}-calico-setup
   namespace: kube-system
-  label: 
+  labels: 
     app: {{ template "CGW.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "CGW.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app: {{ template "CGW.name" . }}
         release: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ template "CGW.fullname" .}}-calico-setup
-      initContainers:
-      - name: {{ .Chart.Name }}-calico-etcd-routing-enabler
-        image: "quay.io/coreos/etcd:latest"
-        command:
-          - /bin/sh
-          - "-xc"
-          - >
-              etcdctl --endpoint=$ENDPOINT set
-              calico/bgp/v1/global/custom_filters/v4/ipsec
-              "if ( net = $REMOTENET ) then { accept ; }"
-        env:
-        - name: ENDPOINT
-          valueFrom:
-            configMapKeyRef:
-              name: calico-config
-              key: etcd_endpoints
-        - name: REMOTENET
-          value: "{{ .Values.ipsec.remotenet }}"
+      hostNetwork: true
+      {{- if .Values.nodeSelector }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "{{ .Values.calicoSetup.excludeHost.key }}"
+                operator: NotIn
+                values:
+                - "{{ .Values.calicoSetup.excludeHost.value }}"
+      {{- end }}
       containers:
-      - name: {{ .Chart.Name }}-calico-setup
-        image: "{{ .Values.calicoSetup.image.repository }}:{{ .Values.calicoSetup.image.tag }}"
+      - name: {{ .Chart.Name }}-calico-setup 
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: alpine:latest
+        command:
+        - sh
+        - -c
+        - |
+          set -euo pipefail
+
+          _remove_route() {
+              echo "ip route del $IPSEC_REMOTENET via $TUNNEL_GATEWAY dev $TUNNEL_INTERFACE onlink"
+              ip route del $IPSEC_REMOTENET via $TUNNEL_GATEWAY dev $TUNNEL_INTERFACE onlink
+              return 0
+          }
+
+          _add_route() {
+              echo "======= setup route ======="
+              echo "ip route add $IPSEC_REMOTENET via $TUNNEL_GATEWAY dev $TUNNEL_INTERFACE onlink"
+              ip route add $IPSEC_REMOTENET via $TUNNEL_GATEWAY dev $TUNNEL_INTERFACE onlink
+          }
+
+          _term() {
+              echo "======= caught SIGTERM signal ======="
+              _remove_route
+              exit 0
+          }
+
+          _add_route
+          trap _term TERM INT
+          while true
+          do
+            echo "going to sleep for 1d"
+            sleep 1d
+          done
+
         env:
-        - name: IPSEC_SERVICE
-          value: {{ template "CGW.fullname" . }}
         - name: IPSEC_REMOTENET
           value: "{{ .Values.ipsec.remotenet }}"
-        - name: IPSEC_NAMESPACE
-          value: "{{ .Release.Namespace }}"
+        - name: TUNNEL_INTERFACE
+          value: "{{ .Values.calicoSetup.interface }}"
+        - name: TUNNEL_GATEWAY
+          value: "{{ .Values.calicoSetup.gateway }}"
         securityContext:
           capabilities:
             add: ["NET_ADMIN"]
-      hostNetwork: true
-   {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-   {{- end }}
-
 {{- end }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.ipsec.hostNetworking }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -28,3 +29,4 @@ spec:
   selector:
     app: {{ template "CGW.name" . }}
     release: {{ .Release.Name }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -56,9 +56,11 @@ resources:
 ## values for setting up calico routing over IPSEC
 calicoSetup:
   enabled: false
-  image:
-    repository: openvnf/helper-ipsec-calico
-    tag: latest
+  excludeHost:
+    key: ipsec-cp
+    value: "true"
+  interface: tunl0
+  gateway: 192.0.2.1
 
 ## Values used to set up GRE usage
 gre:

--- a/values.yaml
+++ b/values.yaml
@@ -12,7 +12,8 @@ ipsec:
   keyexchange: ikev2
   ikecipher: aes192gcm16-aes128gcm16-prfsha256-ecp256-ecp521,aes192-sha256-modp3072
   espcipher: aes192gcm16-aes128gcm16-ecp256,aes192-sha256-modp3072
-  psk: secret
+  psk:
+    value: secret
   forceudp: "yes"
   vti_key: 1304
 replicaCount: 1
@@ -50,6 +51,13 @@ resources:
   requests:
    cpu: 100m
    memory: 128Mi
+
+## values for setting up calico routing over IPSEC
+calicoSetup:
+  enabled: false
+  image:
+    repository: openvnf/helper-ipsec-calico
+    tag: latest
 
 ## Values used to set up GRE usage
 gre:

--- a/values.yaml
+++ b/values.yaml
@@ -2,7 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 useEnvConfig: "HIDDEN_PUBIP_HOST"
-setRouteDefaultTable: FALSE
 ipsec:
   remoteip: 192.0.2.0
   remotenet: 192.168.23.0/24
@@ -16,6 +15,8 @@ ipsec:
     value: secret
   forceudp: "yes"
   vti_key: 1304
+  setDefaultTable: false
+  hostNetworking: false
 replicaCount: 1
 image:
   repository: openvnf/vnf-ipsec


### PR DESCRIPTION
Add feature to configure a kubernetes cluster running with Calico as a networking stack to set routes on the host running the ipsec container automatically and configure calico to propagate these routes.