### PR TITLE
Fix vxlan-controller configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ To use the *vxlan-controller* add the following section to the configuration:
 ```yaml
 vxlanController:
   enabled: true
+  # The following two values are used to set the key names for the key names
+  # and can be infrastructure specific:
+  # annotationKey: vxlan.travelping.com/networks
+  * metadataKey: vxlan.travelping.com
   names: "vxeth0, vxeth1"
   ip:
   - interface: vxeth1

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ vxlanController:
   # The following two values are used to set the key names for the key names
   # and can be infrastructure specific:
   # annotationKey: vxlan.travelping.com/networks
-  * metadataKey: vxlan.travelping.com
+  # metadataKey: vxlan.travelping.com
   names: "vxeth0, vxeth1"
   ip:
   - interface: vxeth1

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -15,9 +15,9 @@ spec:
         app: {{ template "CGW.name" . }}
         release: {{ .Release.Name }}
         {{- if .Values.vxlanController.enabled }}
-        vxlan: "true"
+        {{ .Values.vxlanController.metadataKey }}: "true"
       annotations:
-        vxlan.travelping.com/names: "{{ .Values.vxlanController.names }}"
+        {{ .Values.vxlanController.annotationKey }}: "{{ .Values.vxlanController.names }}"
         {{ end }}
     spec:
       initContainers:

--- a/values.yaml
+++ b/values.yaml
@@ -62,7 +62,7 @@ resources:
      memory: 64Mi
   ipsec:
     limits:
-     cpu: 50m
+     cpu: 200m
      memory: 256Mi
     requests:
      cpu: 200m

--- a/values.yaml
+++ b/values.yaml
@@ -128,6 +128,8 @@ vxlan:
 
 vxlanController:
   enabled: false
+  annotationKey: vxlan.travelping.com/networks
+  metadataKey: vxlan.travelping.com
   names: "vxeth0, vxeth1"
   image:
     repository: aialferov/kube-vxlan-controller-agent


### PR DESCRIPTION
In the new version of the vxlan-controller the annotation key and metadata key are configurable cluster wise.
Therefore configuration parameters to configure these via value files is added.