### PR TITLE
Up default image for pcap to 1.0.1

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -331,7 +331,7 @@ pcap:
   enabled: false
   image:
     repository: travelping/pcap
-    tag: 1.0.0
+    tag: 1.0.1
     pullPolicy: IfNotPresent
 
 radvd:


### PR DESCRIPTION
Please, update the default image for the pcap container. The previous version has the bug - https://github.com/travelping/docker-pcap/commit/2a360d19f3d67190cf02884a74eb1d6a9ecc7365 .