### PR TITLE
additionalSecurityContext for init-script container

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -267,6 +267,9 @@ spec:
         securityContext:
           capabilities:
             add: ["NET_ADMIN"]
+          {{- if .Values.initScript.additionalSecurityContext }}
+{{ toYaml .Values.initScript.additionalSecurityContext | indent 10 }}
+          {{- end }}
         envFrom:
           - configMapRef:
               name: {{ template "CGW.fullname" . }}-init-script-env


### PR DESCRIPTION
Add possibility to add to the `init-script` container's `securityContext`. Makes it possible, for example, to run the init-script container in privileged mode.