### PR TITLE
Double ping-exporter's resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@
 
 Deprecated features or components might be removed in later versions without change in major version number!
 
-## 1.0.1
-
-- Double `ping-exporter's` resources to mitigate wrong results (https://github.com/openvnf/cgw/pull/31).
 
 ## 1.0.0
 
@@ -36,6 +33,7 @@ Deprecated features or components might be removed in later versions without cha
   - using vxlan-connector (`vxlan`) is deprecated
     - use vxlan-controller instead
   - configure IPSEC without using `manualConfig` is deprecated
+- double `ping-exporter's` resources to mitigate wrong results (https://github.com/openvnf/cgw/pull/31)
 
 ## pre 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Deprecated features or components might be removed in later versions without change in major version number!
 
+## 1.0.1
+
+- Double `ping-exporter's` resources to mitigate wrong results (https://github.com/openvnf/cgw/pull/31).
+
 ## 1.0.0
 
 - configuration [breaking]

--- a/values.yaml
+++ b/values.yaml
@@ -132,11 +132,11 @@ resources:
       memory: 64Mi
   pingExporter:
     limits:
+      cpu: 100m
+      memory: 64Mi
+    requests:
       cpu: 50m
       memory: 32Mi
-    requests:
-      cpu: 25m
-      memory: 16Mi
   rclone:
     limits:
       cpu: 50m


### PR DESCRIPTION
Low resources resulted in wrong data from the exporter although on the wire everyting looked fine (https://github.com/travelping/ping-exporter/issues/5).