### PR TITLE
Fix invalid deployment

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -8,7 +8,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  terminationGracePeriodSeconds: 0
   strategy:
     rollingUpdate:
       maxSurge: 0
@@ -46,6 +45,7 @@ spec:
 {{ toYaml .Values.additionalAnnotations | indent 8 }}
         {{- end }}
     spec:
+      terminationGracePeriodSeconds: 0
         {{- if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -754,10 +754,10 @@ spec:
       - name: init-script
         configMap:
           name: {{ template "CGW.fullname" . }}-init-script
+          defaultMode: 0544
           items:
             - key: initScript.sh
               path: initScript.sh
-              defaultMode: 0544
       {{- end }}
       {{- if .Values.bird.enabled }}
       - name: bird-config
@@ -781,10 +781,10 @@ spec:
       - name: radvd-config
         configMap:
           name: {{ template "CGW.fullname" . }}-radvd-config
+          defaultMode: 0444
           items:
             - key: radvd.conf
               path: radvd.conf
-              defaultMode: 0444
       {{- end }}
     {{- if .Values.pullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
This PR fixes two issues with the current templates/deployment.yaml:

* defaultMode for initScripts
* terminationGracePeriodSeconds

`kubeval --strict` should become the start of "unit tests".