### PR TITLE
[VRRP] Add parameter for regular gratuitous ARPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,9 @@ vrrp:
     # priority, should differ between routing functions
     priority: 50
     authPath: secret
+    # interval in which to send gratuitous ARPs in seconds.
+    # 0 for no refreshing.
+    master_refresh: 10
 ```
 
 ### PCAP [alpha]

--- a/templates/vrrp-configmap.yaml
+++ b/templates/vrrp-configmap.yaml
@@ -17,6 +17,7 @@ data:
       virtual_router_id {{ $instance.virtual_router_id }}
       priority {{ $instance.priority }}
       advert_int 1
+      garp_master_refresh {{ $instance.master_refresh }}
       authentication {
           auth_type PASS
           auth_pass {{ $instance.authPath }}


### PR DESCRIPTION
Announce master's MAC every x seconds to counter situations were systems send
packets to wrong MAC address because gratuitous ARP was missed.