### PR TITLE
Use stable K8s deployment API

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "CGW.fullname" . }}


### PR DESCRIPTION
The `Deployment` resource is in the stable `apps/v1` API of K8s v1.9.
Furthermore, K8s v1.16 removed the long deprecated use of
`extensions/v1beta1` for `Deployment`.

This commit fixes this. As a result, this helm chart can not be used
below K8s v1.9.