### PR TITLE
Feature: lz4 compression and by day folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## General Notice
 
-Deprecated features or components might be removed in later versions without change in major version number!
+Deprecated features or components might be removed in later versions without
+change in major version number!
 
 ## 1.0
 
@@ -10,12 +11,14 @@ Deprecated features or components might be removed in later versions without cha
 
 - add value to add sysctls to the security context
 - add value to add additional pod specs
- 
+
 ### 1.3.0
+
 - change deployment strategy to `Recreate` as we had problems with duplicate
   address detection of not yet dead pods.
 
 ### 1.2.2
+
 - reduce packaged helm chart file size from 240kbyte to 21kbyte
 
 ### 1.2.1
@@ -149,4 +152,5 @@ Deprecated features or components might be removed in later versions without cha
 - add option to disable usage of VTI interfaces for IPSEC
 
 ### 0.4.0
--  add cgw-exporter to expose ICMP echo metrics for the service
+
+- add cgw-exporter to expose ICMP echo metrics for the service

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -671,13 +671,15 @@ spec:
            [ -d /data/ ] && watchnames="$watchnames /data/"
            inotifywait --monitor -e close_write --format %w%f $watchnames | while read FILE
            do
-            filename=$(echo $FILE | cut -d '/' -f3 | cut -d '_' -f1)
-            timestamp=$(echo $FILE | cut -d '_' -f3 | cut -d '.' -f1 |  sed 's/./&-/4;s/./&-/7;s/./&_/10;s/./&h/13;s/./&m/16;s/./&s/19')
-            date=$(echo $timestamp | cut -d '_' -f1)
-            format=$(echo $FILE | rev | cut -d '.' -f1 | rev)
-            echo "$FILE is finished. Moving to data/finished/. Attempting to push to $RCLONE_REMOTE_NAME:$RCLONE_REMOTE_PATH/{{ .Values.labels.name }}/${date}/${timestamp}_{{ .Values.labels.name }}_{{ .Values.labels.cluster }}_${filename}.${format}"
-            mv $FILE /data/finished/${timestamp}_{{ .Values.labels.name }}_{{ .Values.labels.cluster }}_${filename}.${format}
-            rclone move /data/finished/ $RCLONE_REMOTE_NAME:$RCLONE_REMOTE_PATH/{{ .Values.labels.name }}/${date}
+            
+            ts=$(stat -c "%Y" $FILE)
+            prefix=$(date +"%Y-%m-%d/%Y-%m-%d-%Hh%Mm%Ss" -d @$ts)
+            suffix=$(echo $FILE | awk '{ gsub(/\./, "_", $0); split($0, f, "_"); printf("%s.%s\n", f[1], f[4]) }')
+            target="${prefix}_{{ .Values.labels.name }}_{{ .Values.labels.cluster }}_${suffix}"
+
+            echo "$FILE is finished. Moving to data/finished/. Attempting to push to $RCLONE_REMOTE_NAME:$RCLONE_REMOTE_PATH/${target}"
+            lz4 --rm "$FILE" "/data/finishes/${target}"
+            rclone move /data/finished/ "$RCLONE_REMOTE_NAME:$RCLONE_REMOTE_PATH/${target}"
            done
       {{- end }}
       volumes:

--- a/values.yaml
+++ b/values.yaml
@@ -350,7 +350,7 @@ rclone:
   useSSHkeyFile: false
   image:
     repository: quay.io/travelping/docker-rclone
-    tag: v1.0
+    tag: v1.1
     pullPolicy: IfNotPresent
   env:
     RCLONE_REMOTE_NAME: "sftp"


### PR DESCRIPTION
   This commit changes the schema of the target file names in various aspects:
    
    * All .pcap files are put into a subfolder grouped by day. This makes
      deleting old data from any remote target much easier. It also reduces
      stress on any file explorer which do not have to spend CPU cycles to
      render 20k files.
    
    * All .pcap files are compressed by .lz4 before uploaded. Usually, this
      reduces the file size to 1/3 of the original size.
    
    * The date part of the timestamp changes from "YYYY_MM_DD" to
      "YYYY-MM-DD".
    
    Underneath, the way how parts of the filename is deduced is changed as
    well. The timestamp is based upon the "change date" of the file. stat(1)
    is able to print the proper timestamp. This makes any sed-orgy
    irrelevant while at the same time opens the door to define the folder
    name. That timestamp is then used to construct a properly filename based
    upon date parts. This makes any sed-orgy to construct something similar
    obsolete.