### PR TITLE
Make date subdirectory optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 Deprecated features or components might be removed in later versions without change in major version number!
 
-## 1.0
+## 1.x
 
+### 1.next
+
+- make the `$date` subdirectory in rclone's target optional
 
 ### 1.5.1
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -673,7 +673,7 @@ spec:
            do
             filename=$(echo $FILE | cut -d '/' -f3 | cut -d '_' -f1)
             timestamp=$(echo $FILE | cut -d '_' -f3 | cut -d '.' -f1 |  sed 's/./&-/4;s/./&-/7;s/./&_/10;s/./&h/13;s/./&m/16;s/./&s/19')
-            date=$(echo $timestamp | cut -d '_' -f1)
+            {{ if .Values.rclone.dateInPath }}date=$(echo $timestamp | cut -d '_' -f1){{ else }}{{ end }}
             format=$(echo $FILE | rev | cut -d '.' -f1 | rev)
             echo "$FILE is finished. Moving to data/finished/. Attempting to push to $RCLONE_REMOTE_NAME:$RCLONE_REMOTE_PATH/{{ .Values.labels.name }}/{{ if .Values.rclone.dateInPath }}${date}{{ else }}{{ end }}/${timestamp}_{{ .Values.labels.name }}_{{ .Values.labels.cluster }}_${filename}.${format}"
             mv $FILE /data/finished/${timestamp}_{{ .Values.labels.name }}_{{ .Values.labels.cluster }}_${filename}.${format}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -675,9 +675,9 @@ spec:
             timestamp=$(echo $FILE | cut -d '_' -f3 | cut -d '.' -f1 |  sed 's/./&-/4;s/./&-/7;s/./&_/10;s/./&h/13;s/./&m/16;s/./&s/19')
             date=$(echo $timestamp | cut -d '_' -f1)
             format=$(echo $FILE | rev | cut -d '.' -f1 | rev)
-            echo "$FILE is finished. Moving to data/finished/. Attempting to push to $RCLONE_REMOTE_NAME:$RCLONE_REMOTE_PATH/{{ .Values.labels.name }}/${date}/${timestamp}_{{ .Values.labels.name }}_{{ .Values.labels.cluster }}_${filename}.${format}"
+            echo "$FILE is finished. Moving to data/finished/. Attempting to push to $RCLONE_REMOTE_NAME:$RCLONE_REMOTE_PATH/{{ .Values.labels.name }}/{{ if .Values.rclone.dateInPath }}${date}{{ else }}{{ end }}/${timestamp}_{{ .Values.labels.name }}_{{ .Values.labels.cluster }}_${filename}.${format}"
             mv $FILE /data/finished/${timestamp}_{{ .Values.labels.name }}_{{ .Values.labels.cluster }}_${filename}.${format}
-            rclone move /data/finished/ $RCLONE_REMOTE_NAME:$RCLONE_REMOTE_PATH/{{ .Values.labels.name }}/${date}
+            rclone move /data/finished/ $RCLONE_REMOTE_NAME:$RCLONE_REMOTE_PATH/{{ .Values.labels.name }}/{{ if .Values.rclone.dateInPath }}${date}{{ else }}{{ end }}
            done
       {{- end }}
       volumes:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -673,11 +673,11 @@ spec:
            do
             filename=$(echo $FILE | cut -d '/' -f3 | cut -d '_' -f1)
             timestamp=$(echo $FILE | cut -d '_' -f3 | cut -d '.' -f1 |  sed 's/./&-/4;s/./&-/7;s/./&_/10;s/./&h/13;s/./&m/16;s/./&s/19')
-            {{ if .Values.rclone.dateInPath }}date=$(echo $timestamp | cut -d '_' -f1){{ else }}{{ end }}
+            {{ if .Values.rclone.dateInPath }}date=$(echo $timestamp | cut -d '_' -f1){{ end }}
             format=$(echo $FILE | rev | cut -d '.' -f1 | rev)
-            echo "$FILE is finished. Moving to data/finished/. Attempting to push to $RCLONE_REMOTE_NAME:$RCLONE_REMOTE_PATH/{{ .Values.labels.name }}/{{ if .Values.rclone.dateInPath }}${date}{{ else }}{{ end }}/${timestamp}_{{ .Values.labels.name }}_{{ .Values.labels.cluster }}_${filename}.${format}"
+            echo "$FILE is finished. Moving to data/finished/. Attempting to push to $RCLONE_REMOTE_NAME:$RCLONE_REMOTE_PATH/{{ .Values.labels.name }}/{{ if .Values.rclone.dateInPath }}${date}/{{ end }}${timestamp}_{{ .Values.labels.name }}_{{ .Values.labels.cluster }}_${filename}.${format}"
             mv $FILE /data/finished/${timestamp}_{{ .Values.labels.name }}_{{ .Values.labels.cluster }}_${filename}.${format}
-            rclone move /data/finished/ $RCLONE_REMOTE_NAME:$RCLONE_REMOTE_PATH/{{ .Values.labels.name }}/{{ if .Values.rclone.dateInPath }}${date}{{ else }}{{ end }}
+            rclone move /data/finished/ $RCLONE_REMOTE_NAME:$RCLONE_REMOTE_PATH/{{ .Values.labels.name }}/{{ if .Values.rclone.dateInPath }}${date}{{ end }}
            done
       {{- end }}
       volumes:

--- a/values.yaml
+++ b/values.yaml
@@ -348,6 +348,7 @@ rclone:
   enabled: false
   filename: "gtp.pcap"
   useSSHkeyFile: false
+  dateInPath: true
   image:
     repository: quay.io/travelping/docker-rclone
     tag: v1.0


### PR DESCRIPTION
Rather dirty way to remove the date from the path in a backwards-compatible way. 

I initially wanted to move the whole script to `values.yaml` but one can not use template variables there, so... 