### PR TITLE
[vrrp] Configurable instance state

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,8 @@ vrrp:
     # interval in which to send gratuitous ARPs in seconds.
     # 0 for no refreshing.
     master_refresh: 10
+    # default state on startup (MASTER|BACKUP, default: MASTER)
+    state: BACKUP
 ```
 
 ### PCAP [alpha]

--- a/templates/vrrp-configmap.yaml
+++ b/templates/vrrp-configmap.yaml
@@ -12,7 +12,7 @@ data:
   keepalived.conf: |
     {{- range $instance := .Values.vrrp.instances }}
     vrrp_instance {{ $instance.name }} {
-      state MASTER
+      state {{ $instance.state | upper | default "MASTER" }}
       interface {{ $instance.interface }}
       virtual_router_id {{ $instance.virtual_router_id }}
       priority {{ $instance.priority }}


### PR DESCRIPTION
Make an instance's initial state configurable so not all instances are MASTER after startup.