### PR TITLE
PoC Simplistic inotify based reloader

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -548,6 +548,13 @@ spec:
           mountPath: /opt/bird/
         - name: bird-socket
           mountPath: /var/run/bird/
+      - name: bird-reloader
+        image: pskamruk/bird-reloader:latest
+        volumeMounts:
+        - name: bird-config
+          mountPath: /opt/bird/
+        - name: bird-socket
+          mountPath: /var/run/bird/
       {{- end }}
 
       {{- if and .Values.bird.enabled .Values.bird.birdExporter.enabled }}


### PR DESCRIPTION
Other option to reload bird configuration, automatically when new changes arrive by configmap update (which requires sometimes up to few minutes, as it has to be handled by the kubelet).

Built around [inotifywait](https://linux.die.net/man/1/inotifywait) runs `configure check` on any write to config files and if check will return OK in its output  - runs `configure`.

Built from: https://github.com/jellonek/bird-reloader/blob/master/bird-reloader.sh

Note: does not provide any endpoint for health status, only info in logs about success or failure.